### PR TITLE
fixed bugs in 1.24, 2.3, and 2.6

### DIFF
--- a/foundation_framework/aws-cis-foundation-benchmark-checklist.py
+++ b/foundation_framework/aws-cis-foundation-benchmark-checklist.py
@@ -1050,7 +1050,7 @@ def control_2_8_ensure_kms_cmk_rotation(regions):
                     keyDescription = kms_client.describe_key(KeyId=keys['Keys'][i]['KeyId'])
                     if "Default master key that protects my" not in keyDescription['KeyMetadata']['Description']:  # Ignore service keys
                         result = False
-                        failReason = "CloudTrail not using KMS CMK for encryption discovered"
+                        failReason = "KMS CMK rotation not enabled"
                         offenders.append("Key:" + str(keyDescription['KeyMetadata']['Arn']))
             except:
                 pass  # Ignore keys without permission, for example ACM key


### PR DESCRIPTION
First, this is awesome! Thanks for putting this together! :)

I was able to get aws-cis-foundation-benchmark-checklist.py to scan my AWS account but I ran into a few bugs.

### 1.24

I got the following exception:

```
$ python ./aws-cis-foundation-benchmark-checklist.py
Traceback (most recent call last):
  File "./aws-cis-foundation-benchmark-checklist.py", line 2221, in <module>
    lambda_handler("test", "test")
  File "./aws-cis-foundation-benchmark-checklist.py", line 2159, in lambda_handler
    control1.append(control_1_24_no_overly_permissive_policies())
  File "./aws-cis-foundation-benchmark-checklist.py", line 763, in control_1_24_no_overly_permissive_policies
    if ("'*'" in str(n['Action']) or str(n['Action']) == "*") and ("'*'" in str(n['Resource']) or str(n['Resource']) == "*"):
TypeError: string indices must be integers
```

This was because the code was assuming that the `Statement` key in the IAM policy would always be an array, but this is not a safe assumption.  I had the following policy in my account:

```
{
    "Version": "2012-10-17",
    "Statement": {
        "Effect": "Allow",
        "Action": "sts:AssumeRole",
        "Resource": "arn:aws:iam::346584093910:role/cross-accout-role"
    }
}
```

This check also assumed that each `Statement` would include an Action which is not safe.  It is possible that it would only include a `NotAction`.

### 2.3 and 2.6

I hit an issue with both of these checks where a Cloudtrail had been configured but the S3 bucket has since been deleted.  

```
$ python ./aws-cis-foundation-benchmark-checklist.py
Traceback (most recent call last):
  File "./aws-cis-foundation-benchmark-checklist.py", line 2178, in <module>
    lambda_handler("test", "test")
  File "./aws-cis-foundation-benchmark-checklist.py", line 2121, in lambda_handler
    control2.append(control_2_3_ensure_cloudtrail_bucket_not_public(cloud_trails))
  File "./aws-cis-foundation-benchmark-checklist.py", line 819, in control_2_3_ensure_cloudtrail_bucket_not_public
    Bucket=o['S3BucketName']
  File "/usr/local/lib/python2.7/site-packages/botocore/client.py", line 159, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python2.7/site-packages/botocore/client.py", line 494, in _make_api_call
    raise ClientError(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (NoSuchBucket) when calling the GetBucketAcl operation: The specified bucket does not exist
```

### 2.8

The `failReason` was inaccurate. 