### PR TITLE
Control 4.1 - bug in SSH port open implementation

### DIFF
--- a/foundation_framework/aws-cis-foundation-benchmark-checklist.py
+++ b/foundation_framework/aws-cis-foundation-benchmark-checklist.py
@@ -1681,7 +1681,7 @@ def control_4_1_ensure_ssh_not_open_to_world(regions):
             if "0.0.0.0/0" in str(m['IpPermissions']):
                 for o in m['IpPermissions']:
                     try:
-                        if int(o['FromPort']) <= 22 <= int(o['ToPort']):
+                        if int(o['FromPort']) <= 22 <= int(o['ToPort']) and '0.0.0.0/0' in str(o['IpRanges']):
                             result = False
                             failReason = "Found Security Group with port 22 open to the world (0.0.0.0/0)"
                             offenders.append(str(m['GroupId']))


### PR DESCRIPTION
Currently the 4.1 check is broken.

Quick way to reproduce it:

1. create SG
2. allow 443 from 0.0.0.0/0
3. allow 22 from a.b.c.d/32

if you run the benchmark, it will mark such secuirty group as offending 4.1 control. That is because statetement on line 1681 (the whole Python object is compared as string):

`
if "0.0.0.0/0" in str(m['IpPermissions']):
`

returns true and inside loop on line 1684 script is checking for port 22 (without checking the actual IP range).

These rules should be evaluated individually & independently. The inner if should be:

`
if int(o['FromPort']) <= 22 <= int(o['ToPort']) and '0.0.0.0/0' in str(o['IpRanges']):
`

With this implementation, the above security group will pass as expected.