### PR TITLE
minor - function for checking 2.7 control is reporting it as 2.6

### DIFF
--- a/foundation_framework/aws-cis-foundation-benchmark-checklist.py
+++ b/foundation_framework/aws-cis-foundation-benchmark-checklist.py
@@ -1017,7 +1017,7 @@ def control_2_7_ensure_cloudtrail_encryption_kms(cloudtrails):
     result = True
     failReason = ""
     offenders = []
-    control = "2.6"
+    control = "2.7"
     description = "Ensure CloudTrail logs are encrypted at rest using KMS CMKs"
     scored = True
     for m, n in cloudtrails.iteritems():


### PR DESCRIPTION
function for checking 2.7 control (`control_2_7_ensure_cloudtrail_encryption_kms`) is reporting it as 2.6. As a result 2.6 is doubled in the final report.