### PR TITLE
Added additional check in 1.24 logic

### DIFF
--- a/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
+++ b/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
@@ -768,7 +768,7 @@ def control_1_24_no_overly_permissive_policies():
 
         for n in statements:
             # a policy statement has to contain either an Action or a NotAction
-            if 'Action' in n.keys():
+            if 'Action' in n.keys() and n['Effect'] == 'Allow':
                 if ("'*'" in str(n['Action']) or str(n['Action']) == "*") and ("'*'" in str(n['Resource']) or str(n['Resource']) == "*"):
                     failReason = "Found full administrative policy"
                     offenders.append(str(m['Arn']))
@@ -1953,7 +1953,7 @@ def get_cloudtrails(regions):
 
 def get_account_number():
     """Summary
-    
+
     Returns:
         TYPE: Description
     """


### PR DESCRIPTION
Added additional check in 1.24 to make sure effect is Allow.  The following IAM policy statement was considered a failure:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Stmt1442222347000",
            "Effect": "Deny",
            "Action": "*",
            "Condition": {
                "StringEquals": {
                    "ec2:Region": [
                        "us-west-1",
                        "us-east-1",
                        "eu-west-1",
                        "eu-central-1",
                        "ap-southeast-1",
                        "ap-southeast-2",
                        "ap-northeast-1",
                        "ap-northeast-2",
                        "sa-east-1"
                    ]
                }
            },
            "Resource": [
                "*"
            ]
        }
    ]
}
```