### PR TITLE
Fix incorrect control number in 2.7

### DIFF
--- a/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
+++ b/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
@@ -1040,7 +1040,7 @@ def control_2_7_ensure_cloudtrail_encryption_kms(cloudtrails):
     result = True
     failReason = ""
     offenders = []
-    control = "2.6"
+    control = "2.7"
     description = "Ensure CloudTrail logs are encrypted at rest using KMS CMKs"
     scored = True
     for m, n in cloudtrails.iteritems():


### PR DESCRIPTION
For some reason (perhaps the directory name change), the fix in #8 isn't reflected in the current master.