### PR TITLE
Fix control_1_3 using wrong field from credreport

### DIFF
--- a/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
+++ b/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
@@ -189,7 +189,7 @@ def control_1_3_unused_credentials(credreport):
     for i in range(len(credreport)):
         if credreport[i]['password_enabled'] == "true":
             try:
-                delta = datetime.strptime(now, frm) - datetime.strptime(credreport[i]['password_last_used_date'], frm)
+                delta = datetime.strptime(now, frm) - datetime.strptime(credreport[i]['password_last_used'], frm)
                 # Verify password have been used in the last 90 days
                 if delta.days > 90:
                     result = False


### PR DESCRIPTION
 * control_1_3 was using a non-existent field from credreport and incorrectly
   passing the test in the exception handling
 * changes the field in credreport from password_last_used_date to
   password_last_used matching what is available in credreport
 * probably should not pass on exception and continue to check keys; separate
   concern