### PR TITLE
removing failures from 3.2 metric filter

### DIFF
--- a/architecture/create-benchmark-rules.yaml
+++ b/architecture/create-benchmark-rules.yaml
@@ -1720,7 +1720,8 @@
         LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
         FilterPattern: "{
             ($.eventName = \"ConsoleLogin\") &&
-            ($.additionalEventData.MFAUsed != \"Yes\")
+            ($.additionalEventData.MFAUsed != \"Yes\") &&
+            ($.responseElements.ConsoleLogin != \"Failure\")
             }"
         MetricTransformations:
           -

--- a/architecture/create-benchmark-rules.yaml
+++ b/architecture/create-benchmark-rules.yaml
@@ -1721,7 +1721,8 @@
         FilterPattern: "{
             ($.eventName = \"ConsoleLogin\") &&
             ($.additionalEventData.MFAUsed != \"Yes\") &&
-            ($.responseElements.ConsoleLogin != \"Failure\")
+            ($.responseElements.ConsoleLogin != \"Failure\") &&
+            ($.additionalEventData.SamlProviderArn NOT EXISTS)
             }"
         MetricTransformations:
           -


### PR DESCRIPTION
Fixes #40 

Excludes login failures from the metric filter.
Excludes SAML logins from metric filter as those can not have an MFA flag.