### PR TITLE
Add Meter filters and alarms for cloudwatch

### DIFF
--- a/architecture/create-benchmark-rules.yaml
+++ b/architecture/create-benchmark-rules.yaml
@@ -1720,7 +1720,8 @@
         LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
         FilterPattern: "{
             ($.eventName = \"ConsoleLogin\") &&
-            ($.additionalEventData.MFAUsed != \"Yes\")
+            ($.additionalEventData.MFAUsed != \"Yes\") &&
+            ($.responseElements.ConsoleLogin != \"Failure\")
             }"
         MetricTransformations:
           -
@@ -1921,6 +1922,46 @@
             Arn: !GetAtt FunctionToFormatCloudWatchEvent.Arn
             Id: TargetFunctionV1
 
+    S3BucketPolicyChangesMetric:
+      Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - ResourceForEvaluateCisBenchmarkingPreconditions
+        - ResourceForGetCloudTrailCloudWatchLog
+      Properties:
+        LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
+        FilterPattern: '{
+          ($.eventSource = s3.amazonaws.com) &&
+            (($.eventName = PutBucketAcl) ||
+            ($.eventName = PutBucketPolicy) ||
+            ($.eventName = PutBucketCors) ||
+            ($.eventName = PutBucketLifecycle) ||
+            ($.eventName = PutBucketReplication) ||
+            ($.eventName = DeleteBucketPolicy) ||
+            ($.eventName = DeleteBucketCors) ||
+            ($.eventName = DeleteBucketLifecycle) ||
+            ($.eventName = DeleteBucketReplication))
+          }'
+        MetricTransformations:
+          -
+            MetricNamespace: CloudTrailMetrics
+            MetricName: S3BucketPolicyChangesMetric
+            MetricValue: 1
+
+    S3BucketPolicyChangesCloudWatchAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: S3 Bucket Policy Changes
+        AlarmDescription: S3 Bucket Policy Changes
+        AlarmActions:
+          - !Ref SnsTopicForCloudWatchEvents
+        MetricName: S3BucketPolicyChangesMetric
+        Namespace: CloudTrailMetrics
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        Statistic: Sum
+        Threshold: 1
+
     #==================================================
     # CIS 3.9	Ensure a log metric filter and alarm exist for AWS Config configuration changes
     #==================================================
@@ -1946,6 +1987,41 @@
           -
             Arn: !GetAtt FunctionToFormatCloudWatchEvent.Arn
             Id: TargetFunctionV1
+
+    AwsConfigChangesMetric:
+      Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - ResourceForEvaluateCisBenchmarkingPreconditions
+        - ResourceForGetCloudTrailCloudWatchLog
+      Properties:
+        LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
+        FilterPattern: '{
+          ($.eventSource = config.amazonaws.com) &&
+            (($.eventName=StopConfigurationRecorder) ||
+            ($.eventName=DeleteDeliveryChannel) ||
+            ($.eventName=PutDeliveryChannel) ||
+            ($.eventName=PutConfigurationRecorder))
+        }'
+        MetricTransformations:
+          -
+            MetricNamespace: CloudTrailMetrics
+            MetricName: AwsConfigChangesMetric
+            MetricValue: 1
+
+    AwsConfigChangesCloudWatchAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: Aws Cfg Changes
+        AlarmDescription: Aws Cfg Changes
+        AlarmActions:
+          - !Ref SnsTopicForCloudWatchEvents
+        MetricName: AwsConfigChangesMetric
+        Namespace: CloudTrailMetrics
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        Statistic: Sum
+        Threshold: 1
 
     #==================================================
     # KMS Key Use Detection
@@ -1992,6 +2068,41 @@
             Arn: !GetAtt FunctionToFormatCloudWatchEvent.Arn
             Id: TargetFunctionV1
 
+    CloudtrailCfgChangesMetric:
+      Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - ResourceForEvaluateCisBenchmarkingPreconditions
+        - ResourceForGetCloudTrailCloudWatchLog
+      Properties:
+        LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
+        FilterPattern: '{
+          ($.eventName = CreateTrail) ||
+          ($.eventName = UpdateTrail) ||
+          ($.eventName = DeleteTrail) ||
+          ($.eventName = StartLogging) ||
+          ($.eventName = StopLogging)
+          }'
+        MetricTransformations:
+          -
+            MetricNamespace: CloudTrailMetrics
+            MetricName: CloudtrailCfgChangesMetric
+            MetricValue: 1
+
+    CloudtrailCfgChangesCloudWatchAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: Cloudtrail Cfg Changes
+        AlarmDescription: Cloudtrail Cfg Changes
+        AlarmActions:
+          - !Ref SnsTopicForCloudWatchEvents
+        MetricName: CloudtrailCfgChangesMetric
+        Namespace: CloudTrailMetrics
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        Statistic: Sum
+        Threshold: 1
+
     #==================================================
     # CIS 3.4	Ensure a log metric filter and alarm exist for IAM policy changes
     #==================================================
@@ -2029,6 +2140,52 @@
           -
             Arn: !GetAtt FunctionToFormatCloudWatchEvent.Arn
             Id: TargetFunctionV1
+
+    IamChangesMetric:
+      Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - ResourceForEvaluateCisBenchmarkingPreconditions
+        - ResourceForGetCloudTrailCloudWatchLog
+      Properties:
+        LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
+        FilterPattern: '{
+          ($.eventName=DeleteGroupPolicy) ||
+          ($.eventName=DeleteRolePolicy) ||
+          ($.eventName=DeleteUserPolicy) ||
+          ($.eventName = PutGroupPolicy) ||
+          ($.eventName = PutRolePolicy) ||
+          ($.eventName = PutUserPolicy) ||
+          ($.eventName = CreatePolicy) ||
+          ($.eventName = DeletePolicy) ||
+          ($.eventName = CreatePolicyVersion) ||
+          ($.eventName = DeletePolicyVersion) ||
+          ($.eventName = AttachRolePolicy) ||
+          ($.eventName = DetachRolePolicy) ||
+          ($.eventName = AttachUserPolicy) ||
+          ($.eventName = DetachUserPolicy) ||
+          ($.eventName = AttachGroupPolicy) ||
+          ($.eventName = DetachGroupPolicy)
+          }'
+        MetricTransformations:
+          -
+            MetricNamespace: CloudTrailMetrics
+            MetricName: IamChangesMetric
+            MetricValue: 1
+
+    IamChangesCloudWatchAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: IAM Changes
+        AlarmDescription: IAM Changes
+        AlarmActions:
+          - !Ref SnsTopicForCloudWatchEvents
+        MetricName: IamChangesMetric
+        Namespace: CloudTrailMetrics
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        Statistic: Sum
+        Threshold: 1
 
     #==================================================
     # Billing Change Detection
@@ -2104,6 +2261,42 @@
             Arn: !GetAtt FunctionToFormatCloudWatchEvent.Arn
             Id: TargetFunctionV1
 
+    SecurityGroupChangesMetric:
+      Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - ResourceForEvaluateCisBenchmarkingPreconditions
+        - ResourceForGetCloudTrailCloudWatchLog
+      Properties:
+        LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
+        FilterPattern: '{
+          ($.eventName = AuthorizeSecurityGroupIngress) ||
+          ($.eventName = AuthorizeSecurityGroupEgress) ||
+          ($.eventName = RevokeSecurityGroupIngress) ||
+          ($.eventName = RevokeSecurityGroupEgress) ||
+          ($.eventName = CreateSecurityGroup) ||
+          ($.eventName = DeleteSecurityGroup)
+          }'
+        MetricTransformations:
+          -
+            MetricNamespace: CloudTrailMetrics
+            MetricName: SecurityGroupChangesMetric
+            MetricValue: 1
+
+    SecurityGroupChangesCloudWatchAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: Security Group Changes
+        AlarmDescription: Security Group Changes
+        AlarmActions:
+          - !Ref SnsTopicForCloudWatchEvents
+        MetricName: SecurityGroupChangesMetric
+        Namespace: CloudTrailMetrics
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        Statistic: Sum
+        Threshold: 1
+
     #==================================================
     # CIS 3.11	Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL)
     #==================================================
@@ -2131,6 +2324,42 @@
           -
             Arn: !GetAtt FunctionToFormatCloudWatchEvent.Arn
             Id: TargetFunctionV1
+
+    NaclChangesMetric:
+      Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - ResourceForEvaluateCisBenchmarkingPreconditions
+        - ResourceForGetCloudTrailCloudWatchLog
+      Properties:
+        LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
+        FilterPattern:  '{
+          ($.eventName = CreateNetworkAcl) ||
+          ($.eventName = CreateNetworkAclEntry) ||
+          ($.eventName = DeleteNetworkAcl) ||
+          ($.eventName = DeleteNetworkAclEntry) ||
+          ($.eventName = ReplaceNetworkAclEntry) ||
+          ($.eventName = ReplaceNetworkAclAssociation)
+        }'
+        MetricTransformations:
+          -
+            MetricNamespace: CloudTrailMetrics
+            MetricName: NaclChangesMetric
+            MetricValue: 1
+
+    NaclChangesCloudWatchAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: NACL Changes
+        AlarmDescription: NACL Changes
+        AlarmActions:
+          - !Ref SnsTopicForCloudWatchEvents
+        MetricName: NaclChangesMetric
+        Namespace: CloudTrailMetrics
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        Statistic: Sum
+        Threshold: 1
 
     #==================================================
     # CIS 3.12	Ensure a log metric filter and alarm exist for changes to network gateways
@@ -2197,6 +2426,120 @@
         AlarmActions:
           - !Ref SnsTopicForCloudWatchEvents
         MetricName: BillingEventCount
+        Namespace: CloudTrailMetrics
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        Statistic: Sum
+        Threshold: 1
+
+    NetworkGwChangesMetric:
+      Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - ResourceForEvaluateCisBenchmarkingPreconditions
+        - ResourceForGetCloudTrailCloudWatchLog
+      Properties:
+        LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
+        FilterPattern:  '{
+          ($.eventName = CreateCustomerGateway) ||
+          ($.eventName = DeleteCustomerGateway) ||
+          ($.eventName = AttachInternetGateway) ||
+          ($.eventName = CreateInternetGateway) ||
+          ($.eventName = DeleteInternetGateway) ||
+          ($.eventName = DetachInternetGateway)
+          }'
+        MetricTransformations:
+          -
+            MetricNamespace: CloudTrailMetrics
+            MetricName: NetworkGwChangesMetric
+            MetricValue: 1
+
+    NetworkGwChangesCloudWatchAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: Network GW Changes
+        AlarmDescription: Network GW Changes
+        AlarmActions:
+          - !Ref SnsTopicForCloudWatchEvents
+        MetricName: NetworkGwChangesMetric
+        Namespace: CloudTrailMetrics
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        Statistic: Sum
+        Threshold: 1
+
+    RouteTableChangesMetric:
+      Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - ResourceForEvaluateCisBenchmarkingPreconditions
+        - ResourceForGetCloudTrailCloudWatchLog
+      Properties:
+        LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
+        FilterPattern: '{
+          ($.eventName = CreateRoute) ||
+          ($.eventName = CreateRouteTable) ||
+          ($.eventName = ReplaceRoute) ||
+          ($.eventName = ReplaceRouteTableAssociation) ||
+          ($.eventName = DeleteRouteTable) ||
+          ($.eventName = DeleteRoute) ||
+          ($.eventName = DisassociateRouteTable)
+          }'
+        MetricTransformations:
+          -
+            MetricNamespace: CloudTrailMetrics
+            MetricName: RouteTableChangesMetric
+            MetricValue: 1
+
+    RouteTableChangesCloudWatchAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: Route Table Changes
+        AlarmDescription: Route Table Changes
+        AlarmActions:
+          - !Ref SnsTopicForCloudWatchEvents
+        MetricName: RouteTableChangesMetric
+        Namespace: CloudTrailMetrics
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        Period: 60
+        Statistic: Sum
+        Threshold: 1
+
+    VpcChangesMetric:
+      Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - ResourceForEvaluateCisBenchmarkingPreconditions
+        - ResourceForGetCloudTrailCloudWatchLog
+      Properties:
+        LogGroupName: !GetAtt ResourceForGetCloudTrailCloudWatchLog.LogName
+        FilterPattern: '{
+          ($.eventName = CreateVpc) ||
+          ($.eventName = DeleteVpc) ||
+          ($.eventName = ModifyVpcAttribute) ||
+          ($.eventName = AcceptVpcPeeringConnection) ||
+          ($.eventName = CreateVpcPeeringConnection) ||
+          ($.eventName = DeleteVpcPeeringConnection) ||
+          ($.eventName = RejectVpcPeeringConnection) ||
+          ($.eventName = AttachClassicLinkVpc) ||
+          ($.eventName = DetachClassicLinkVpc) ||
+          ($.eventName = DisableVpcClassicLink) ||
+          ($.eventName = EnableVpcClassicLink)
+          }'
+        MetricTransformations:
+          -
+            MetricNamespace: CloudTrailMetrics
+            MetricName: VpcChangesMetric
+            MetricValue: 1
+
+    VpcChangesCloudWatchAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: VPC Changes
+        AlarmDescription: VPC Changes
+        AlarmActions:
+          - !Ref SnsTopicForCloudWatchEvents
+        MetricName: VpcChangesMetric
         Namespace: CloudTrailMetrics
         ComparisonOperator: GreaterThanOrEqualToThreshold
         EvaluationPeriods: 1


### PR DESCRIPTION
This is a fix for issue @36 it adds the missing meter filters and alarms to the Cloud Formation template.