### PR TITLE
Update aws-cis-foundation-benchmark-checklist.py

### DIFF
--- a/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
+++ b/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
@@ -986,7 +986,7 @@ def control_2_5_ensure_config_all_regions(regions):
             if response['DeliveryChannelsStatus'][0]['configHistoryDeliveryInfo']['lastStatus'] != "SUCCESS":
                 result = False
                 failReason = "Config not enabled in all regions, not capturing all/global events or delivery channel errors"
-                offenders.append(str(n) + ":S3Delivery")
+                offenders.append(str(n) + ":S3orSNSDelivery")
         except:
             pass  # Will be captured by earlier rule
         try:


### PR DESCRIPTION
AWS Config's history delivery has two components; a) periodically deliver recorded ConfigurationItems (CI's) to S3 bucket configured in delivery channel and b) after each S3 delivery send notification to SNS topic about the object delivered.  ConfigHistoryDeliveryInfo will reflect failure status if either the S3 delivery or SNS notification failed.