### PR TITLE
1.21 terminated instances should not be included

### DIFF
--- a/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
+++ b/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
@@ -691,6 +691,7 @@ def control_1_21_ensure_iam_instance_roles_used():
             if response['Reservations'][n]['Instances'][0]['IamInstanceProfile']:
                 pass
         except:
+            if response['Reservations'][n]['Instances'][0]['State']['Name'] != 'terminated':
                 result = False
                 offenders.append(str(response['Reservations'][n]['Instances'][0]['InstanceId']))
     return {'Result': result, 'failReason': failReason, 'Offenders': offenders, 'ScoredControl': scored, 'Description': description, 'ControlId': control}


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes: Terminated instances in EC2 show the IAM role as blank, this results in false positives when running the script.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
