### PR TITLE
Reducing scope on rules

### DIFF
--- a/architecture/create-benchmark-rules.yaml
+++ b/architecture/create-benchmark-rules.yaml
@@ -333,7 +333,7 @@
           SourceDetails:
             -
               EventSource: aws.config
-              MessageType: ConfigurationItemChangeNotification
+              MessageType: ScheduledNotification
           SourceIdentifier: !GetAtt FunctionForEvaluateRootAccountRule.Arn
 
     ConfigRuleForRequiredTags:
@@ -988,7 +988,7 @@
           SourceDetails:
             -
               EventSource: aws.config
-              MessageType: ConfigurationItemChangeNotification
+              MessageType: ScheduledNotification
           SourceIdentifier: !GetAtt FunctionForEvaluateCloudTrailRule.Arn
 
     #==================================================
@@ -1104,7 +1104,7 @@
           SourceDetails:
             -
               EventSource: aws.config
-              MessageType: ConfigurationItemChangeNotification
+              MessageType: ScheduledNotification
           SourceIdentifier: !GetAtt FunctionForEvaluateCloudTrailBucketRule.Arn
 
     #==================================================
@@ -1202,7 +1202,7 @@
           SourceDetails:
             -
               EventSource: aws.config
-              MessageType: ConfigurationItemChangeNotification
+              MessageType: ScheduledNotification
           SourceIdentifier: !GetAtt FunctionForEvaluateCloudTrailLogIntegrityRule.Arn
 
     #==================================================
@@ -1382,9 +1382,6 @@
           SourceDetails:
             -
               EventSource: aws.config
-              MessageType: ConfigurationItemChangeNotification
-            -
-              EventSource: aws.config
               MessageType: ScheduledNotification
 
     #==================================================
@@ -1484,9 +1481,6 @@
         Source:
           Owner: CUSTOM_LAMBDA
           SourceDetails:
-            -
-              EventSource: aws.config
-              MessageType: ConfigurationItemChangeNotification
             -
               EventSource: aws.config
               MessageType: ScheduledNotification


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating rules that are overscoped. 

Triggering on all configuration changes doesn't make sense for these particular rules, and is expensive under the new per-evaluation pricing plan.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
